### PR TITLE
Fixed PIL imports + french translation improvements

### DIFF
--- a/bin/user/gaugeengine.py
+++ b/bin/user/gaugeengine.py
@@ -103,7 +103,7 @@ Directions for use:
 import time
 import syslog
 import os.path
-import Image
+from PIL import Image
 
 import weeutil.weeutil
 import weewx.reportengine

--- a/bin/user/gauges.py
+++ b/bin/user/gauges.py
@@ -19,8 +19,8 @@
 
 import math
 
-import ImageDraw
-import ImageFont
+from PIL import ImageDraw
+from PIL import ImageFont
 
 DEFAULT_FONT = "/usr/share/fonts/truetype/freefont/FreeSans.ttf"
 

--- a/skins/languages/francais.conf
+++ b/skins/languages/francais.conf
@@ -14,27 +14,24 @@
         #
         # Generic labels, keyed by an observation type.
         #
-        barometer      = Pression barométrique
+        barometer      = Pression atmosphérique
+        dewpoint       = Point de rosée
+        inHumidity     = Humidité intérieure
+        inTemp         = Température intérieure
+        heatindex      = Indice de chaleur
         outHumidity    = Taux d'humidité
-        inTemp         = Température
+        outTemp        = Température extérieure
         radiation      = Ensoleillement
         rain           = Précipitations
+        rainRate       = Intensité de précipitations
+        rainRateMax    = Intensité max.
         windSpeed      = Vitesse du vent
         windDir        = Direction du vent
         windGust       = Vitesse des rafales
         windGustDir    = Direction des rafales
-        windchill      = Température ressentie
-
-#       Don't have any translations for these yet:
-#
-        dewpoint       = Point de rosée
-        heatindex      = Indice de chaleur
-        inHumidity     = Humidité intérieure
-        outTemp        = Température extérieure
-        rainRate       = Taux de pluie
+        windchill      = Refroidissement éolien
         windgustvec    = Vecteur des rafales
         windvec        = Vecteur du vent
-
 
 [BootstrapLabels]
 
@@ -48,17 +45,18 @@
         front_page  = Météo en direct
         stats       = Statistiques
         history     = Historique
-        news        = Nouvelles
+        news        = Actualités
         about       = Information
         last_update = Mise à jour :
 
     [[timespans]]
-        day      = Dernières 24 heures
-        today    = Hier             # today = any time since midnight
-        week     = Cette semaine
-        month    = Ce mois
-        year     = Cette année
-        ever     = Depuis toujours
+        day       = Dernières 24 heures
+        yesterday = Hier
+        today     = Aujourd'hui            # today = any time since midnight
+        week      = Cette semaine
+        month     = Ce mois
+        year      = Cette année
+        ever      = Depuis toujours
 
     [[status]]
         latitude       = Latitude :
@@ -72,8 +70,8 @@
         max_temp = Températures maximums
         avg_temp = Températures moyennes
         rain     = Précipitations
-        radiation= Maximum Radiation Solaire
-        UV       = Maximum UV Index
+        radiation= Radiation solaire maxi
+        UV       = Indice UV maxi
         NOAA     = Données NOAA
 
     [[minmax]]


### PR DESCRIPTION
When using pillow instead of PIL, some imports does not work without specifying that there are imported from the "PIL" module.
For exemple, this does not work :
```python
import Image
```
but this will work :
```python
from PIL import Image
```