### PR TITLE
cn.conf changed to zh.conf

### DIFF
--- a/install.py
+++ b/install.py
@@ -74,8 +74,7 @@ class BootstrapInstaller(setup.ExtensionInstaller):
             'skins/Bootstrap/js/site.js',
             'skins/Bootstrap/js/units.js']),
            ('skins/Bootstrap/lang',
-            ['skins/Bootstrap/lang/cn.conf',
-             'skins/Bootstrap/lang/cz.conf',
+            ['skins/Bootstrap/lang/cz.conf',
              'skins/Bootstrap/lang/de.conf',
              'skins/Bootstrap/lang/en.conf',
              'skins/Bootstrap/lang/es.conf',
@@ -84,7 +83,8 @@ class BootstrapInstaller(setup.ExtensionInstaller):
              'skins/Bootstrap/lang/it.conf',
              'skins/Bootstrap/lang/nl.conf',
              'skins/Bootstrap/lang/no.conf',
-             'skins/Bootstrap/lang/th.conf'])]
+             'skins/Bootstrap/lang/th.conf',
+             'skins/Bootstrap/lang/zh.conf'])]
 
         version="4.2"
         super(BootstrapInstaller, self).__init__(


### PR DESCRIPTION
sudo wee_extension --install .
Request to install '.'

The following alternative languages are available:
   cn
   cz
   de
   en
   es
   fr
   gr
   it
   nl
   no
   th

Change to a different language following the description at:
   http://www.weewx.com/docs/customizing.htm#localization

Default location for HTML and image files is public_html/Bootstrap
*** POINT YOUR BROWSER TO: public_html/Bootstrap/index.html ***

Traceback (most recent call last):
  File "/usr/share/weewx/wee_extension", line 92, in <module>
    main()
  File "/usr/share/weewx/wee_extension", line 84, in main
    ext.install_extension(options.install)
  File "/usr/share/weewx/weecfg/extension.py", line 137, in install_extension
    self.install_from_dir(extension_path)
  File "/usr/share/weewx/weecfg/extension.py", line 183, in install_from_dir
    shutil.copy(source_path, destination_path)
  File "/usr/lib/python3.11/shutil.py", line 419, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.11/shutil.py", line 256, in copyfile
    with open(src, 'rb') as fsrc:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './skins/Bootstrap/lang/cn.conf'