### PR TITLE
Added option to disable stuck needle behavior.

### DIFF
--- a/skins/Bootstrap/js/gauges.js
+++ b/skins/Bootstrap/js/gauges.js
@@ -35,8 +35,8 @@ function loadGauges() {
         let splitnumber = gauge.weewxData.splitnumber;
         let gaugeName = gauge.weewxData.gaugeName === undefined ? weewxData.labels.Generic[gaugeId] : gauge.weewxData.gaugeName;
         let axisTickSplitNumber = 5;
-        gauge.weewxData.heatMapEnabled = parseBoolean(gauge.weewxData.heatMapEnabled);
-        gauge.weewxData.stuckNeedleEnabled = parseBoolean(gauge.weewxData.stuckNeedleEnabled);
+        gauge.weewxData.heatMapEnabled = parseBooleanDefaultTrue(gauge.weewxData.heatMapEnabled);
+        gauge.weewxData.stuckNeedleEnabled = parseBooleanDefaultTrue(gauge.weewxData.stuckNeedleEnabled);
         if (gauge.weewxData.obs_group === "group_direction") {
             minvalue = 0;
             maxvalue = 360;
@@ -93,12 +93,19 @@ function loadGauges() {
     }
 }
 
-function parseBoolean(value) {
+function parseBooleanDefaultTrue(value) {
+    return parseBoolean(value, true);
+}
+
+function parseBooleanDefaultFalse(value) {
+    return parseBoolean(value, false);
+}
+
+function parseBoolean(value, defaultValue) {
     if (value !== undefined && value.toLowerCase() === "false") {
         return false;
-    } else {
-        return true;
     }
+    return defaultValue;
 }
 
 function getGaugeOption(name, min, max, splitNumber, axisTickSplitNumber, lineColor, unit, weewxData) {

--- a/skins/Bootstrap/js/site.js
+++ b/skins/Bootstrap/js/site.js
@@ -124,6 +124,7 @@ function setGaugeValue(gauge, value, timestamp) {
 
 function updateGaugeValue(newValue, gauge) {
     let option = gauge.getOption();
+    option.series[0].pointer.show = true;
     let currentValue = option.series[0].data[0].value;
     if (gauge.isCircular !== undefined && gauge.isCircular && Math.abs(newValue - currentValue) > 180) {
         let currentAnimationEasingUpdate = option.series[0].animationEasingUpdate;

--- a/skins/Bootstrap/skin.conf
+++ b/skins/Bootstrap/skin.conf
@@ -771,8 +771,9 @@
         lineColor = '#428bca', '#b44242'       # colors are RGBa
         lineColorUntil = 32, maxvalue          # color from start of gauge to value, change color of gauge ring to show important marks: 32 is freezing point
         decimals = 1                           # decimals for current value in gauge
-        #heatMapEnabled = false                # disabled heatmap for gauge, default true
+        #heatMapEnabled = false                # disable heatmap for gauge, default true
         #animation = False                     # default true
+        #stuckNeedleEnabled = false            # disable stuck needle for gauge, default true. While enabled, it will show the most recent value if there is no current value.
 
     [[barometer]]
         payload_key = barometer_inHg           # barometer_mbar if target_unit 'METRICWX', or 'METRIC'


### PR DESCRIPTION
This pull request hides the pointer and value display when no value is available in the latest archive record (or when the database is new / empty).

Here's an example of what this looks like:
<img width="175" alt="image" src="https://github.com/brewster76/fuzzy-archer/assets/2065015/bf62c519-7f3e-4519-8359-9bcd4992a1f6">

This PR also avoids displaying NaN and misleading pointers on an empty database.