### PR TITLE
Live gauge directions for windDir

### DIFF
--- a/bin/user/jsonengine.py
+++ b/bin/user/jsonengine.py
@@ -140,7 +140,7 @@ class JSONGenerator(weewx.reportengine.ReportGenerator):
                     self.frontend_data[category + "_daily_high_low"] = daily_highlow_values
         for gauge in self.gauge_dict.sections:
             gauge_config = self.frontend_data['gauges'][gauge]
-            ret, gauge_history = self.gen_history_data(gauge, gauge_config, self.gauge_dict[gauge].get('data_binding'))
+            ret, gauge_history, _ = self.gen_history_data(gauge, gauge_config, self.gauge_dict[gauge].get('data_binding'))
             gauge_config['target_unit'] = self.get_target_unit(gauge)
             gauge_config['obs_group'] = self.get_obs_group(gauge)
 
@@ -192,7 +192,7 @@ class JSONGenerator(weewx.reportengine.ReportGenerator):
 
         if obs_name in self.frontend_data:
             log.debug("Data for observation %s has already been collected." % obs_name)
-            return None, None
+            return None, None, None
         else:
             try:
                 if binding_name:
@@ -210,7 +210,7 @@ class JSONGenerator(weewx.reportengine.ReportGenerator):
             target_unit = self.get_target_unit(column_name)
         except:
             log.info("JSONGenerator: *** Could not find target unit of measure for column '%s' ***" % column_name)
-            return 0, None
+            return 0, None, None
 
         aggregate_types = []
         if item_config.get('showMaxMarkPoint', 'false') == 'true':

--- a/skins/Bootstrap/js/gauges.js
+++ b/skins/Bootstrap/js/gauges.js
@@ -43,6 +43,7 @@ function loadGauges() {
             splitnumber = 4;
             axisTickSplitNumber = 4;
             colors = [[0.25, gauge.weewxData.lineColorN], [0.5, gauge.weewxData.lineColorS], [0.75, gauge.weewxData.lineColorS], [1, gauge.weewxData.lineColorN]];
+            gauge.weewxData.directionValuesEnabled = parseBooleanDefaultFalse(gauge.weewxData.directionValuesEnabled);
         } else {
             let lineColors = Array.isArray(gauge.weewxData.lineColor) ? gauge.weewxData.lineColor : [gauge.weewxData.lineColor];
             let lineColorUntilValues = Array.isArray(gauge.weewxData.lineColorUntil) ? gauge.weewxData.lineColorUntil : [gauge.weewxData.lineColorUntil];
@@ -88,6 +89,13 @@ function loadGauges() {
             };
             gaugeOption.series[0].title.offsetCenter = ['0', '-25%'];
             gaugeOption.series[0].detail.offsetCenter = ['0', '30%'];
+            if (gauge.weewxData.directionValuesEnabled) {
+                gaugeOption.series[0].detail.formatter = function (value) {
+                    let directionIndex = Math.round((Number(value)+11.25)/22.5);
+                    let directionValues = weewxData.units.Ordinates.directions === undefined ? ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N'] : weewxData.units.Ordinates.directions ;
+                    return directionValues[directionIndex];
+                };
+            }
         }
         gauge.setOption(gaugeOption);
     }
@@ -104,7 +112,7 @@ function parseBooleanDefaultFalse(value) {
 function parseBoolean(value, defaultValue) {
     if (value !== undefined) {
         if (value.toLowerCase() === "false") {
-        return false;
+            return false;
         } else if (value.toLowerCase() === "true") {
             return true;
         } else {

--- a/skins/Bootstrap/js/gauges.js
+++ b/skins/Bootstrap/js/gauges.js
@@ -102,8 +102,14 @@ function parseBooleanDefaultFalse(value) {
 }
 
 function parseBoolean(value, defaultValue) {
-    if (value !== undefined && value.toLowerCase() === "false") {
+    if (value !== undefined) {
+        if (value.toLowerCase() === "false") {
         return false;
+        } else if (value.toLowerCase() === "true") {
+            return true;
+        } else {
+            return defaultValue;
+        }
     }
     return defaultValue;
 }

--- a/skins/Bootstrap/skin.conf
+++ b/skins/Bootstrap/skin.conf
@@ -800,7 +800,7 @@ version = 4.3
         lineColor = '#428bca'
         lineColorUntil = maxvalue
         decimals = 0
-        #directionValuesEnabled = false       # enable for Ordinate Directions to show as Gauge Value
+        #directionValuesEnabled = true        # enable for Ordinate Directions to show as Gauge Value
 
     [[windSpeed]]
         payload_key = windSpeed_mph           # windSpeed_mps if target_unit 'METRICWX', windSpeed_kph if 'METRIC'

--- a/skins/Bootstrap/skin.conf
+++ b/skins/Bootstrap/skin.conf
@@ -800,6 +800,7 @@ version = 4.3
         lineColor = '#428bca'
         lineColorUntil = maxvalue
         decimals = 0
+        #directionValuesEnabled = false       # enable for Ordinate Directions to show as Gauge Value
 
     [[windSpeed]]
         payload_key = windSpeed_mph           # windSpeed_mps if target_unit 'METRICWX', windSpeed_kph if 'METRIC'


### PR DESCRIPTION
Allow for Ordinate directions on winDir Live Gauge. This is disabled by default to allow for backward compatability. Note: Issue #169 needs finalising for the True value to be picked up for the Default False option. Option is enabled by setting directionValuesEnabled = True.