### PR TITLE
Enable Oridnate Directions for windDir Live Gauge

### DIFF
--- a/skins/Bootstrap/js/gauges.js
+++ b/skins/Bootstrap/js/gauges.js
@@ -43,6 +43,7 @@ function loadGauges() {
             splitnumber = 4;
             axisTickSplitNumber = 4;
             colors = [[0.25, gauge.weewxData.lineColorN], [0.5, gauge.weewxData.lineColorS], [0.75, gauge.weewxData.lineColorS], [1, gauge.weewxData.lineColorN]];
+            gauge.weewxData.directionValuesEnabled = parseBooleanDefaultFalse(gauge.weewxData.directionValuesEnabled);
         } else {
             let lineColors = Array.isArray(gauge.weewxData.lineColor) ? gauge.weewxData.lineColor : [gauge.weewxData.lineColor];
             let lineColorUntilValues = Array.isArray(gauge.weewxData.lineColorUntil) ? gauge.weewxData.lineColorUntil : [gauge.weewxData.lineColorUntil];
@@ -88,6 +89,13 @@ function loadGauges() {
             };
             gaugeOption.series[0].title.offsetCenter = ['0', '-25%'];
             gaugeOption.series[0].detail.offsetCenter = ['0', '30%'];
+            if (gauge.weewxData.directionValuesEnabled) {
+                gaugeOption.series[0].detail.formatter = function (value) {
+                    let directionIndex = Math.floor((Number(value)+11.25)/22.5);
+                    let directionValues = weewxData.units.Ordinates.directions === undefined ? ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N/A'] : weewxData.units.Ordinates.directions ;
+                    return directionValues[directionIndex];
+                };
+            }
         }
         gauge.setOption(gaugeOption);
     }

--- a/skins/Bootstrap/skin.conf
+++ b/skins/Bootstrap/skin.conf
@@ -791,6 +791,7 @@ version = 4.3
         lineColorN = '#428bca'
         lineColorS = '#b44242'
         decimals = 0
+        #directionValuesEnabled = true        # enable for Ordinate Directions to show as Gauge Value
 
     [[outHumidity]]
         payload_key = outHumidity


### PR DESCRIPTION
Enable Oridnate Directions for windDir Live Gauge. This is set by enabling directionValuesEnabled = true, which is available to be uncommented in skin as per example below. NOTE: Issue #169 needs to be finalised for the true value of the setting to be honoured for the DefaultFalse setting.

```
    [[windDir]] #windDir is a special, circular direction gauge, options are limited
        payload_key = windDir
        lineColorN = '#428bca'
        lineColorS = '#b44242'
        directionValuesEnabled = true         # enable for Ordinate Directions to show as Gauge Value
        decimals = 0
```