### PR TITLE
Fixup Orindate showing as N/A when degress greater than 348.75

### DIFF
--- a/skins/Bootstrap/js/gauges.js
+++ b/skins/Bootstrap/js/gauges.js
@@ -92,6 +92,7 @@ function loadGauges() {
             if (gauge.weewxData.directionValuesEnabled) {
                 gaugeOption.series[0].detail.formatter = function (value) {
                     let directionIndex = Math.floor((Number(value)+11.25)/22.5);
+                    directionIndex = directionIndex == 16 ? 0 : directionIndex;
                     let directionValues = weewxData.units.Ordinates.directions === undefined ? ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N/A'] : weewxData.units.Ordinates.directions ;
                     return directionValues[directionIndex];
                 };

--- a/skins/Bootstrap/js/gauges.js
+++ b/skins/Bootstrap/js/gauges.js
@@ -91,10 +91,14 @@ function loadGauges() {
             gaugeOption.series[0].detail.offsetCenter = ['0', '30%'];
             if (gauge.weewxData.directionValuesEnabled) {
                 gaugeOption.series[0].detail.formatter = function (value) {
-                    let directionIndex = Math.floor((Number(value)+11.25)/22.5);
-                    directionIndex = directionIndex == 16 ? 0 : directionIndex;
-                    let directionValues = weewxData.units.Ordinates.directions === undefined ? ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N/A'] : weewxData.units.Ordinates.directions ;
-                    return directionValues[directionIndex];
+                    let ordinals = weewxData.units.Ordinates.directions === undefined ? ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N/A'] : weewxData.units.Ordinates.directions ;
+                    if(isNaN(value)) {
+                        return ordinals[-1];
+                    }
+                    let sectorSize = 360.0 / ((ordinals.length)-1);
+                    let degree = (value + sectorSize/2.0) % 360.0;
+                    let sector = Math.floor(degree / sectorSize);
+                    return ordinals[sector];
                 };
             }
         }


### PR DESCRIPTION
When creating the feature I borrowed from another project which circled backed to 'N' in the Ordinate array. The ordinate labels in this skin have index 16 (17th position) as 'N/A'. So for degress greater than 348.75, 'N/A' showed. This PR fixes this error.