### PR TITLE
Nav dropdown submenu

### DIFF
--- a/skins/Bootstrap/nav.html.inc
+++ b/skins/Bootstrap/nav.html.inc
@@ -18,8 +18,16 @@
                 #if 'title' in $Navigation[$nav_item]
                 #set $hrefTitle = $Navigation[$nav_item]['title']
                 #end if
-                <li class="nav-item">
-                    <a id="${nav_item}Html" class="nav-link${active}" href="$href" title="$gettext($hrefTitle)">
+                #set $extraLinkAttributes = ''
+                #set $listItemClasses = 'nav-item'
+                #set $linkClasses = 'nav-link' + $active
+                #if 'navigation_items' in $Navigation[$nav_item]
+                #set $extraLinkAttributes = 'data-bs-toggle="dropdown" role="button" aria-expanded="false"'
+                #set $listItemClasses = $listItemClasses + ' dropdown'
+                #set $linkClasses  = $linkClasses  + ' dropdown-toggle'
+                #end if
+                <li class="$listItemClasses">
+                    <a id="${nav_item}Html" class="$linkClasses" href="$href" title="$gettext($hrefTitle)" $extraLinkAttributes>
                     #set $icon = 'bi-file-x'
                     #if 'icon' in $Navigation[$nav_item]
                     #set $icon = $Navigation[$nav_item]['icon']
@@ -27,6 +35,21 @@
                     <i class="$icon fs-2 d-inline d-md-none" title="$gettext($Navigation[$nav_item]['text'])"></i>
                     <span class="d-none d-md-inline">$gettext($Navigation[$nav_item]['text'])</span>
                     </a>
+                    ## Submenu Items
+                    #if 'navigation_items' in $Navigation[$nav_item]
+                    <ul class="dropdown-menu">
+                      #for $nav_sub_item in $Navigation[$nav_item]['navigation_items']
+                      #set $href = $Navigation[$nav_item][$nav_sub_item]['href']
+                      #set $hrefTitle = ''
+                      #if 'title' in $Navigation[$nav_item][$nav_sub_item]
+                      #set $hrefTitle = $Navigation[$nav_item][$nav_sub_item]['title']
+                      #end if
+                      <li><a id="${nav_sub_item}Html" class="dropdown-item" href="$href" title="$gettext($hrefTitle)">
+                      $gettext($Navigation[$nav_item][$nav_sub_item]['text'])
+                      </a></li>
+                      #end for
+                    </ul>
+                    #end if
                 </li>
                 #end for
             </ul>

--- a/skins/Bootstrap/skin.conf
+++ b/skins/Bootstrap/skin.conf
@@ -169,6 +169,20 @@ version = 4.3
         text = About
         href = about.html
         icon = bi-question
+    #Example with Submenu Dropdown
+    #[[sample-menu]]
+    #    text = Sample Menu
+    #    href = "#"
+    #    icon = bi-file
+    #    navigation-items = submenu1, submenu2
+    #    [[[submenu1]]]
+    #        text = Submenu 1
+    #        href = page1.html
+    #        title = title
+    #    [[[submenu2]]]
+    #        text = Submenu 2
+    #        href = page2.html
+    #        title = title
 [HistoryColors]
     # minvalues and colors and fontColors should contain the same number of elements.
     #


### PR DESCRIPTION
Allow for Nav Dropdown SubMenu as per https://getbootstrap.com/docs/5.3/components/navs-tabs/#tabs-with-dropdowns

My Config for [Carlingford Weather Bootstrap](https://bootstrap.carlingfordweather.sydney/)

```
    [[webcams]]
        text = Webcams
        href = "#"
        icon = bi-camera-video
        navigation_items = webcam1, webcam2
        [[[webcam1]]]
            text = Webcam West
            href = https://carlingfordweather.sydney/webcam.html
        [[[webcam2]]]
            text = Webcam North
            href = https://carlingfordweather.sydney/webcam2.html
```